### PR TITLE
mapFields configuration accepts Hash paths

### DIFF
--- a/src/Auth/OAuthAuthenticate.php
+++ b/src/Auth/OAuthAuthenticate.php
@@ -236,8 +236,8 @@ class OAuthAuthenticate extends BaseAuthenticate
         }
 
         foreach ($map as $dst => $src) {
-            $data[$dst] = $data[$src];
-            unset($data[$src]);
+            $data[$dst] = Hash::get($data, $src);
+            Hash::remove($data, $src);
         }
 
         return $data;

--- a/src/Auth/OAuthAuthenticate.php
+++ b/src/Auth/OAuthAuthenticate.php
@@ -237,7 +237,7 @@ class OAuthAuthenticate extends BaseAuthenticate
 
         foreach ($map as $dst => $src) {
             $data[$dst] = Hash::get($data, $src);
-            Hash::remove($data, $src);
+            $data = Hash::remove($data, $src);
         }
 
         return $data;


### PR DESCRIPTION
Some providers use nested structures in response data (e.g., Google+ email addresses).  This patch allows [Hash paths](http://book.cakephp.org/3.0/en/core-libraries/hash.html) in the map configuration, and is backwards compatible.
