### PR TITLE
CakePHP 3.6 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
+  - 7.3
 
 sudo: false
 
@@ -16,29 +17,35 @@ matrix:
   fast_finish: true
 
   include:
-    - php: 5.5
+    - php: 7.2
       env: PHPCS=1 DEFAULT=0
 
-    - php: 5.5
+    - php: 7.2
       env: COVERALLS=1 DEFAULT=0
 
-  allow_failures:
-    - php: 7.1
+    - php: 5.6
+      env: PREFER_LOWEST=1
 
 before_script:
-  - composer self-update
-  - composer install --prefer-dist --no-interaction
+  # we do only need xdebug on the version where we want code coverage
+  # xdebug is not released for PHP 7.3 so we cannot remove it
+  - if [[ $TRAVIS_PHP_VERSION != 7.2 && $TRAVIS_PHP_VERSION != 7.3 ]]; then phpenv config-rm xdebug.ini; fi
 
-  - sh -c "if [ '$PHPCS' = '1' ]; then composer require cakephp/cakephp-codesniffer:dev-master; fi"
+  - if [[ $PREFER_LOWEST != 1 ]]; then composer update --no-interaction ; fi
+  - if [[ $PREFER_LOWEST == 1 ]]; then composer update --no-interaction --prefer-lowest --prefer-stable; fi
 
-  - sh -c "if [ '$COVERALLS' = '1' ]; then composer require --dev satooshi/php-coveralls:dev-master; fi"
-  - sh -c "if [ '$COVERALLS' = '1' ]; then mkdir -p build/logs; fi"
+  - if [[ $PHPCS == 1 ]]; then composer require cakephp/cakephp-codesniffer:"^3.0"; fi
+
+  - if [[ $COVERALLS == 1 ]]; then composer require --dev php-coveralls/php-coveralls; fi
+  - if [[ $COVERALLS == 1 ]]; then mkdir -p build/logs; fi
 
 script:
-  - sh -c "if [ '$DEFAULT' = '1' ]; then phpunit --stderr; fi"
-  - sh -c "if [ '$PHPCS' = '1' ]; then ./vendor/bin/phpcs -p --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests; fi"
-  - sh -c "if [ '$COVERALLS' = '1' ]; then phpunit --stderr --coverage-clover build/logs/clover.xml; fi"
-  - sh -c "if [ '$COVERALLS' = '1' ]; then php vendor/bin/coveralls -c .coveralls.yml -v; fi"
+  - if [[ i$DEFAULT == 1  ]]; then vendor/bin/phpunit; fi
+  
+  - if [[ $COVERALLS == 1 ]]; then vendor/bin/phpunit --coverage-clover=clover.xml; fi
+  - if [[ $COVERALLS == 1 ]]; then php vendor/bin/coveralls -c .coveralls.yml -v; fi
+
+  - if [[ $PHPCS == 1 ]]; then vendor/bin/phpcs -n -p --extensions=php  --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests; fi
 
 notifications:
   email: false

--- a/composer.json
+++ b/composer.json
@@ -33,10 +33,9 @@
         "source": "https://github.com/usemuffin/oauth2"
     },
     "require-dev": {
-        "cakephp/cakephp": "^3.0",
-        "cakephp/cakephp-codesniffer": "^2.0",
-        "league/oauth2-github": "^0.2",
-        "phpunit/phpunit": "*"
+        "cakephp/cakephp": "^3.5",
+        "league/oauth2-github": "^2.0",
+        "phpunit/phpunit": "^5.7.14|^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/TestCase/Auth/OAuthAuthenticateTest.php
+++ b/tests/TestCase/Auth/OAuthAuthenticateTest.php
@@ -12,6 +12,7 @@ use Muffin\OAuth2\Auth\OAuthAuthenticate;
 class OAuthAuthenticateTest extends TestCase
 {
     public $class = 'Muffin\OAuth2\Auth\OAuthAuthenticate';
+
     public $config = [
         'providers' => [
             'github' => [

--- a/tests/TestCase/Auth/OAuthAuthenticateTest.php
+++ b/tests/TestCase/Auth/OAuthAuthenticateTest.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace Muffin\OAuth2\Test\TestCase\Auth;
 
 use Cake\Event\Event;
 use Cake\Event\EventManager;
-use Cake\Network\Request;
-use Cake\Network\Response;
+use Cake\Http\Response;
+use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
 use Muffin\OAuth2\Auth\OAuthAuthenticate;
 
@@ -22,7 +23,7 @@ class OAuthAuthenticateTest extends TestCase
                 ],
                 'mapFields' => [
                     'username' => 'login',
-                ]
+                ],
             ],
         ],
     ];
@@ -66,6 +67,7 @@ class OAuthAuthenticateTest extends TestCase
     {
         $this->markTestIncomplete('Not implemented yet.');
     }
+
     public function testNormalizeConfigThrowsException()
     {
         $this->markTestIncomplete('Not implemented yet.');
@@ -89,25 +91,27 @@ class OAuthAuthenticateTest extends TestCase
         return [
             [
                 $config,
-                ['github' => [
-                    'className' => 'League\OAuth2\Client\Provider\Github',
-                    'options' => [
-                        'clientId' => 'foo',
-                        'clientSecret' => 'bar',
-                        'state' => $config['options']['state'],
+                [
+                    'github' => [
+                        'className' => 'League\OAuth2\Client\Provider\Github',
+                        'options' => [
+                            'clientId' => 'foo',
+                            'clientSecret' => 'bar',
+                            'state' => $config['options']['state'],
+                        ],
+                        'collaborators' => [],
+                        'fields' => [
+                            'username' => 'username',
+                            'password' => 'password',
+                        ],
+                        'userModel' => 'Users',
+                        'scope' => [],
+                        'contain' => null,
+                        'passwordHasher' => 'Default',
+                        'finder' => 'all',
+                        'mapFields' => [],
                     ],
-                    'collaborators' => [],
-                    'fields' => [
-                        'username' => 'username',
-                        'password' => 'password',
-                    ],
-                    'userModel' => 'Users',
-                    'scope' => [],
-                    'contain' => null,
-                    'passwordHasher' => 'Default',
-                    'finder' => 'all',
-                    'mapFields' => [],
-                ]]
+                ],
             ],
         ];
     }
@@ -134,12 +138,12 @@ class OAuthAuthenticateTest extends TestCase
     public function testGetUserMissingProviderInRequest()
     {
         $oauth = new OAuthAuthenticate($this->registry, $this->config);
-        $this->assertFalse($oauth->getUser(new Request('/', ['query' => ['code' => 'foo']])));
+        $this->assertFalse($oauth->getUser(new ServerRequest(['url' => '/', 'query' => ['code' => 'foo']])));
     }
 
     public function testGetUserMissingCodeInQuery()
     {
-        $request = new Request(['url' => '/', 'params' => ['provider' => 'github']]);
+        $request = new ServerRequest(['url' => '/', 'params' => ['provider' => 'github']]);
         $result = $this->oauth->getUser($request);
         $this->assertFalse($result);
     }
@@ -171,7 +175,7 @@ class OAuthAuthenticateTest extends TestCase
 
         $this->assertEquals($data, $result);
 
-        $this->oauth->config($this->oauth->config('providers.github'));
+        $this->oauth->setConfig($this->oauth->getConfig('providers.github'));
         $result = $this->invokeMethod('_map', [$data]);
         $expected = ['username' => 'foo', 'more' => 'stuff'];
         $this->assertEquals($expected, $result);
@@ -180,13 +184,13 @@ class OAuthAuthenticateTest extends TestCase
     public function testProviderMissingFromRequest()
     {
         $oauth = new OAuthAuthenticate($this->registry, $this->config);
-        $this->assertFalse($oauth->provider(new Request('/')));
+        $this->assertFalse($oauth->provider(new ServerRequest('/')));
     }
 
     public function testProvider()
     {
-        $request = new Request(['url' => '/', 'params' => ['provider' => 'github']]);
-            $oauth = $this->createMockForOAuth(['_getProvider']);
+        $request = new ServerRequest(['url' => '/', 'params' => ['provider' => 'github']]);
+        $oauth = $this->createMockForOAuth(['_getProvider']);
 
         $oauth->expects($this->once())
             ->method('_getProvider')
@@ -251,8 +255,8 @@ class OAuthAuthenticateTest extends TestCase
 
     public function testGetUserWithMissingOrAlteredQueryState()
     {
-        $this->oauth->config($this->oauth->normalizeConfig($this->config));
-        $this->oauth->config($this->oauth->config('providers.github'), false);
+        $this->oauth->setConfig($this->oauth->normalizeConfig($this->config));
+        $this->oauth->setConfig($this->oauth->getConfig('providers.github'), false);
 
         $provider = $this->getMockBuilder('League\OAuth2\Client\Provider\Github')
             ->disableOriginalConstructor()
@@ -265,13 +269,13 @@ class OAuthAuthenticateTest extends TestCase
         $url = '/';
         $params = ['provider' => 'github'];
         $query = ['code' => 'bar', 'state' => 'foo'];
-        $request = new Request(compact('url', 'params', 'query'));
+        $request = new ServerRequest(compact('url', 'params', 'query'));
 
         $result = $this->oauth->getUser($request);
         $this->assertFalse($result);
 
         $query += ['state' => 'foo'];
-        $request = new Request(compact('url', 'params', 'query'));
+        $request = new ServerRequest(compact('url', 'params', 'query'));
 
         $result = $this->oauth->getUser($request);
         $this->assertFalse($result);
@@ -287,8 +291,8 @@ class OAuthAuthenticateTest extends TestCase
     public function testGetUser()
     {
         EventManager::instance()->on('Muffin/OAuth2.newUser', [$this, 'newUser']);
-        $this->oauth->config($this->oauth->normalizeConfig($this->config));
-        $this->oauth->config($this->oauth->config('providers.github'), false);
+        $this->oauth->setConfig($this->oauth->normalizeConfig($this->config));
+        $this->oauth->setConfig($this->oauth->getConfig('providers.github'), false);
 
         $token = $this->getMockBuilder('League\OAuth2\Client\Token\AccessToken')
             ->disableOriginalConstructor()
@@ -313,8 +317,7 @@ class OAuthAuthenticateTest extends TestCase
             ->with($token)
             ->will($this->returnValue($owner));
 
-
-        $session = $this->getMockBuilder('Cake\Network\Session')->getMock();
+        $session = $this->getMockBuilder('Cake\Http\Session')->getMock();
         $session->expects($this->once())
             ->method('read')
             ->with('oauth2state')
@@ -331,7 +334,7 @@ class OAuthAuthenticateTest extends TestCase
         $url = '/';
         $params = ['provider' => 'github'];
         $query = ['code' => 'bar', 'state' => 'foobar'];
-        $request = new Request(compact('url', 'params', 'query', 'session'));
+        $request = new ServerRequest(compact('url', 'params', 'query', 'session'));
 
         $result = $this->oauth->getUser($request);
         $this->assertEquals(['username' => 'foo', 'token' => $token], $result);
@@ -341,7 +344,7 @@ class OAuthAuthenticateTest extends TestCase
     {
         $oauth = new OAuthAuthenticate($this->registry, $this->config);
 
-        $request = new Request('/');
+        $request = new ServerRequest('/');
         $response = new Response();
         $result = $oauth->unauthenticated($request, $response);
         $this->assertNull($result);
@@ -350,18 +353,18 @@ class OAuthAuthenticateTest extends TestCase
 
         $query = ['code' => 'bar'];
         $params = ['provider' => 'github'];
-        $request = new Request(compact('url', 'params', 'query'));
+        $request = new ServerRequest(compact('url', 'params', 'query'));
         $response = new Response();
         $result = $oauth->unauthenticated($request, $response);
         $this->assertNull($result);
 
         $query = ['code' => 'bar'];
-        $request = new Request(compact('url', 'query'));
+        $request = new ServerRequest(compact('url', 'query'));
         $response = new Response();
         $result = $oauth->unauthenticated($request, $response);
         $this->assertNull($result);
 
-        $session = $this->getMockBuilder('Cake\Network\Session')
+        $session = $this->getMockBuilder('Cake\Http\Session')
             ->setMethods(['write'])
             ->getMock();
         $session->expects($this->once())
@@ -370,19 +373,19 @@ class OAuthAuthenticateTest extends TestCase
 
         $expected = '/https:\/\/github\.com\/login\/oauth\/authorize\?/';
         $params = ['provider' => 'github'];
-        $request = new Request(compact('url', 'params', 'session'));
+        $request = new ServerRequest(compact('url', 'params', 'session'));
         $response = new Response();
         $result = $oauth->unauthenticated($request, $response);
-        $this->assertInstanceOf('Cake\Network\Response', $result);
-        $this->assertRegExp($expected, $result->location());
+        $this->assertInstanceOf('Cake\Http\Response', $result);
+        $this->assertRegExp($expected, $result->getHeaderLine('Location'));
 
-        $oauth->config('options.state', null);
+        $oauth->setConfig('options.state', null);
         $expected = '/https:\/\/github\.com\/login\/oauth\/authorize\?/';
         $params = ['provider' => 'github'];
-        $request = new Request(compact('url', 'params', 'session'));
+        $request = new ServerRequest(compact('url', 'params', 'session'));
         $response = new Response();
         $result = $oauth->unauthenticated($request, $response);
-        $this->assertInstanceOf('Cake\Network\Response', $result);
-        $this->assertRegExp($expected, $result->location());
+        $this->assertInstanceOf('Cake\Http\Response', $result);
+        $this->assertRegExp($expected, $result->getHeaderLine('Location'));
     }
 }


### PR DESCRIPTION
No longer uses deprecated methods and now users `\Cake\Http\` Request/Response objects